### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 基于MCP协议的多格式图像转换服务器，支持JPG/PNG/WebP/GIF/BMP/TIFF/SVG/ICO/AVIF等格式互转。
 
+<a href="https://glama.ai/mcp/servers/@pickstar-2002/image-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pickstar-2002/image-mcp/badge" alt="Image Converter Server MCP server" />
+</a>
+
 ## 🚀 快速开始
 
 ### 安装


### PR DESCRIPTION
This PR adds a badge for the [Image Converter MCP Server](https://glama.ai/mcp/servers/@pickstar-2002/image-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@pickstar-2002/image-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pickstar-2002/image-mcp/badge" alt="Image Converter Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.